### PR TITLE
Adicionado integração com o docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,31 @@
+version: "3"
+
+volumes:
+    database:
+
+services:
+    database:
+      image: mysql
+      container_name: mysql
+      volumes:
+          - database:/var/lib/mysql
+      ports:
+          - ${DB_PORT}:3306
+      environment:
+        MYSQL_ROOT_PASSWORD: ${DB_PASSWORD}
+        MYSQL_DATABASE: ${DB_DATABASE}
+      restart: unless-stopped
+
+    myAdmin:
+      image: phpmyadmin
+      container_name: myAdmin
+      environment:
+        PMA_HOST: database
+        PMA_USER: root
+        PMA_PASSWORD: ${DB_PASSWORD}
+      ports:
+          - 8080:80
+      depends_on:
+        - database
+      restart: unless-stopped
+


### PR DESCRIPTION
### Motivations

Eu estou atualmente usando alguns serviços no docker entre eles o mysql, ai quando preciso usar o xampp tenho que para todos os serviços que estou usando por conta de alguns conflitos.
Outro motivo é que provavelmente será necessário a adição de novos serviços como redis, elastic-search..., usando docker fica muito mais simples para todo mundo que tiver contribuindo no projeto manter os ambientes padronizados, e quando tiver adição de algo novo é só digitar um comando no terminal e tá tudo rodando.

Adicionei um arquivo de configuração para o docker-composer com os seguintes serviços
- mysql
- phpMyAdmin

#### Duvidas

- Devo adicionar o php também?
- Devo adicionar configuração para gerar uma imagem docker?